### PR TITLE
runtime: Update to GNOME 48

### DIFF
--- a/dev.deedles.Trayscale.yml
+++ b/dev.deedles.Trayscale.yml
@@ -1,7 +1,7 @@
 app-id: dev.deedles.Trayscale
 
 runtime: org.gnome.Platform
-runtime-version: '47'
+runtime-version: '48'
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang


### PR DESCRIPTION
New runtime brings altered dark theme and corner radii of Libadwaita 1.7