### PR TITLE
remove unused, commented-out cache config

### DIFF
--- a/dev.deedles.Trayscale.yml
+++ b/dev.deedles.Trayscale.yml
@@ -22,8 +22,6 @@ finish-args:
 
 build-options:
   prepend-path: /usr/lib/sdk/golang/bin
-  #build-args:
-  #  - --filesystem=home # Allows access to the Go build cache for easier local testing.
 
 modules:
   - name: trayscale


### PR DESCRIPTION
This is mostly to get Flathub to publish a new build so that it'll use Go 1.25.