### PR TITLE
Fix flatpak being sigkilled when closed to tray

### DIFF
--- a/dev.deedles.Trayscale.yml
+++ b/dev.deedles.Trayscale.yml
@@ -18,6 +18,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.portal.Background
   - --metadata=X-DConf=migrate-path=/dev/deedles/Trayscale/
 
 build-options:


### PR DESCRIPTION
This change adds the Background-Portal permission to the flatpak. This fixes https://github.com/DeedleFake/trayscale/issues/242